### PR TITLE
update timer trigger to account for UTC & DST

### DIFF
--- a/src/functions/racineCourtwatchScraper.ts
+++ b/src/functions/racineCourtwatchScraper.ts
@@ -1,10 +1,14 @@
 import { app, InvocationContext, Timer } from "@azure/functions";
 
-export async function racineCourtwatchScraper(myTimer: Timer, context: InvocationContext): Promise<void> {
-    context.log('Timer function processed request.');
+export async function racineCourtwatchScraper(
+  myTimer: Timer,
+  context: InvocationContext
+): Promise<void> {
+  context.log("Timer function processed request", JSON.stringify(myTimer));
 }
 
-app.timer('racineCourtwatchScraper', {
-    schedule: '0 30 12 * * 1-5',
-    handler: racineCourtwatchScraper
+app.timer("racineCourtwatchScraper", {
+  // Run Mon-Fri @ 11:30 am & 12:30 pm CT to account for DST
+  schedule: "0 30 17-18 * * 1-5",
+  handler: racineCourtwatchScraper,
 });


### PR DESCRIPTION
The default time zone for Azure functions is UTC, so the cron schedule needs to be updated to for CDT & CST.