### PR TITLE
Move to trunk-based development

### DIFF
--- a/.github/workflows/azure-functions-app-nodejs.yml
+++ b/.github/workflows/azure-functions-app-nodejs.yml
@@ -2,10 +2,11 @@ name: Deploy Azure Function App
 
 on:
   push:
-    branches: ["dev", "main"]
+    branches: ["main"]
   workflow_dispatch:
 
 env:
+  AZURE_FUNCTIONAPP_NAME: "racinecourtwatchscraper"
   AZURE_FUNCTIONAPP_PACKAGE_PATH: "."
   NODE_VERSION: "20.x"
 
@@ -13,11 +14,6 @@ jobs:
   build-and-deploy-test:
     runs-on: ubuntu-latest
     environment: test
-    if: github.ref == 'refs/heads/dev'
-
-    env:
-      AZURE_FUNCTIONAPP_NAME: "racinecourtwatchscraper"
-
     steps:
       - name: "Checkout GitHub Action"
         uses: actions/checkout@v4
@@ -47,11 +43,7 @@ jobs:
   build-and-deploy-prod:
     runs-on: ubuntu-latest
     environment: production
-    if: github.ref == 'refs/heads/main'
-
-    env:
-      AZURE_FUNCTIONAPP_NAME: "racinecourtwatchscraper"
-
+    needs: build-and-deploy-test
     steps:
       - name: "Checkout GitHub Action"
         uses: actions/checkout@v4

--- a/.github/workflows/azure-functions-app-nodejs.yml
+++ b/.github/workflows/azure-functions-app-nodejs.yml
@@ -1,0 +1,79 @@
+name: Deploy Azure Function App
+
+on:
+  push:
+    branches: ["dev", "main"]
+  workflow_dispatch:
+
+env:
+  AZURE_FUNCTIONAPP_PACKAGE_PATH: "."
+  NODE_VERSION: "20.x"
+
+jobs:
+  build-and-deploy-test:
+    runs-on: ubuntu-latest
+    environment: test
+    if: github.ref == 'refs/heads/dev'
+
+    env:
+      AZURE_FUNCTIONAPP_NAME: "racinecourtwatchscraper"
+
+    steps:
+      - name: "Checkout GitHub Action"
+        uses: actions/checkout@v4
+
+      - name: Setup Node ${{ env.NODE_VERSION }} Environment
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: "Resolve Project Dependencies Using Npm"
+        shell: bash
+        run: |
+          pushd './${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}'
+          npm install
+          npm run build --if-present
+          npm run test --if-present
+          popd
+
+      - name: "Run Azure Functions Action"
+        uses: Azure/functions-action@v1
+        id: fa
+        with:
+          app-name: ${{ env.AZURE_FUNCTIONAPP_NAME }}
+          package: ${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}
+          publish-profile: ${{ secrets.AZURE_FUNCTIONAPP_PUBLISH_PROFILE }}
+
+  build-and-deploy-prod:
+    runs-on: ubuntu-latest
+    environment: production
+    if: github.ref == 'refs/heads/main'
+
+    env:
+      AZURE_FUNCTIONAPP_NAME: "racinecourtwatchscraper"
+
+    steps:
+      - name: "Checkout GitHub Action"
+        uses: actions/checkout@v4
+
+      - name: Setup Node ${{ env.NODE_VERSION }} Environment
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: "Resolve Project Dependencies Using Npm"
+        shell: bash
+        run: |
+          pushd './${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}'
+          npm install
+          npm run build --if-present
+          npm run test --if-present
+          popd
+
+      - name: "Run Azure Functions Action"
+        uses: Azure/functions-action@v1
+        id: fa
+        with:
+          app-name: ${{ env.AZURE_FUNCTIONAPP_NAME }}
+          package: ${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}
+          publish-profile: ${{ secrets.AZURE_FUNCTIONAPP_PUBLISH_PROFILE }}

--- a/src/functions/racineCourtwatchScraper.ts
+++ b/src/functions/racineCourtwatchScraper.ts
@@ -1,10 +1,14 @@
 import { app, InvocationContext, Timer } from "@azure/functions";
 
-export async function racineCourtwatchScraper(myTimer: Timer, context: InvocationContext): Promise<void> {
-    context.log('Timer function processed request.');
+export async function racineCourtwatchScraper(
+  myTimer: Timer,
+  context: InvocationContext
+): Promise<void> {
+  context.log("Timer function processed request", JSON.stringify(myTimer));
 }
 
-app.timer('racineCourtwatchScraper', {
-    schedule: '0 30 12 * * 1-5',
-    handler: racineCourtwatchScraper
+app.timer("racineCourtwatchScraper", {
+  // Run Mon-Fri @ 11:30 am & 12:30 pm CT to account for DST
+  schedule: "0 30 17-18 * * 1-5",
+  handler: racineCourtwatchScraper,
 });


### PR DESCRIPTION
Removing `dev` branch and instead just creating branches off of `main`. Updating Github actions to deploy to test env with every push and then to prod env when it succeeds (pending manual approval).