### PR TITLE
set Prisma generator engine type

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,6 +1,7 @@
 generator client {
   provider      = "prisma-client-js"
   binaryTargets = ["native", "debian-openssl-1.1.x"]
+  engineType    = "binary"
 }
 
 datasource db {


### PR DESCRIPTION
Sets the Prisma generator `engineType` value to `binary` based on Azure error logs